### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ NVClippingDetection *CDT = [[NVClippingDetection alloc] init];
 ```
 
 ### Example project
-See `/Examples/NVDSPExample` for a simple iOS XCodeProject example. Please note the Novocaine bundled with it might be outdated.
+See `/Examples/NVDSPExample` for a simple iOS XcodeProject example. Please note the Novocaine bundled with it might be outdated.
 
 ### A thing to note
 The NVDSP class is written in C++, so the classes that use it will have to be Objective-C++. Change all the files that use NVDSP from MyClass.m to MyClass.mm.


### PR DESCRIPTION
This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
